### PR TITLE
Add CPU install guide and simple SMPL betas inference

### DIFF
--- a/documentation/INSTALL.md
+++ b/documentation/INSTALL.md
@@ -15,6 +15,8 @@ The code has been tested with Python 3.8, CUDA 10.2 and PyTorch 1.7.1 on Ubuntu 
     conda install pytorch==1.7.1 torchvision==0.8.2 cpuonly -c pytorch -y
     python -m pip install "pip<24.1"
     pip install -r requirements.txt
+    REM install Pillow through conda to avoid missing DLL errors on Windows
+    conda install pillow -y
 
     cd attributes
     python setup.py install

--- a/documentation/INSTALL.md
+++ b/documentation/INSTALL.md
@@ -13,7 +13,8 @@ The code has been tested with Python 3.8, CUDA 10.2 and PyTorch 1.7.1 on Ubuntu 
     conda create -n shapy python=3.8 -y
     conda activate shapy
     conda install pytorch==1.7.1 torchvision==0.8.2 cpuonly -c pytorch -y
-    python -m pip install "pip<24.1"
+    REM pip>=24 cannot install omegaconf 2.0.6
+    python -m pip install pip==23.3.1
     pip install -r requirements.txt
     REM install Pillow through conda to avoid missing DLL errors on Windows
     conda install pillow -y
@@ -30,6 +31,10 @@ The code has been tested with Python 3.8, CUDA 10.2 and PyTorch 1.7.1 on Ubuntu 
     pip install -r requirements.txt
     python setup.py install
     ```
+
+**Note:** If the requirements installation complains about invalid metadata for
+`omegaconf==2.0.6`, make sure `python -m pip --version` reports a version below
+24.0 and reinstall pip as shown above.
 
 ### Body model and model data
 

--- a/documentation/INSTALL.md
+++ b/documentation/INSTALL.md
@@ -19,7 +19,11 @@ The code has been tested with Python 3.8, CUDA 10.2 and PyTorch 1.7.1 on Ubuntu 
     cd attributes
     python setup.py install
 
+    REM optional: build mesh-mesh-intersection (requires the CUDA toolkit)
+    REM skip these commands if CUDA is not installed
     cd ..\mesh-mesh-intersection
+    REM set CUDA_HOME to your CUDA installation path
+    set CUDA_HOME=C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v10.2
     set CUDA_SAMPLES_INC=%cd%\include
     pip install -r requirements.txt
     python setup.py install

--- a/documentation/INSTALL.md
+++ b/documentation/INSTALL.md
@@ -13,6 +13,7 @@ The code has been tested with Python 3.8, CUDA 10.2 and PyTorch 1.7.1 on Ubuntu 
     conda create -n shapy python=3.8 -y
     conda activate shapy
     conda install pytorch==1.7.1 torchvision==0.8.2 cpuonly -c pytorch -y
+    python -m pip install "pip<24.1"
     pip install -r requirements.txt
 
     cd attributes

--- a/documentation/INSTALL.md
+++ b/documentation/INSTALL.md
@@ -19,6 +19,7 @@ The code has been tested with Python 3.8, CUDA 10.2 and PyTorch 1.7.1 on Ubuntu 
     python setup.py install
 
     cd ..\mesh-mesh-intersection
+    set CUDA_SAMPLES_INC=%cd%\include
     pip install -r requirements.txt
     python setup.py install
     ```

--- a/documentation/INSTALL.md
+++ b/documentation/INSTALL.md
@@ -4,21 +4,21 @@
 
 The code has been tested with Python 3.8, CUDA 10.2 and PyTorch 1.7.1 on Ubuntu 18.04.
 
-- Clone this repo, create virtual environment & install requirements
-    ```
-    git clone git@github.com:muelea/shapy.git
+- Clone this repo, create a conda environment (CPU-only example for Windows) & install requirements
+    ```cmd
+    git clone https://github.com/muelea/shapy.git
     cd shapy
-    export PYTHONPATH=$PYTHONPATH:$(pwd)/attributes/
+    set PYTHONPATH=%PYTHONPATH%;%cd%\attributes
 
-    python3.8 -m venv .venv/shapy
-    source .venv/shapy/bin/activate
+    conda create -n shapy python=3.8 -y
+    conda activate shapy
+    conda install pytorch==1.7.1 torchvision==0.8.2 cpuonly -c pytorch -y
     pip install -r requirements.txt
 
     cd attributes
     python setup.py install
 
-    cd ../mesh-mesh-intersection
-    export CUDA_SAMPLES_INC=$(pwd)/include
+    cd ..\mesh-mesh-intersection
     pip install -r requirements.txt
     python setup.py install
     ```

--- a/documentation/INSTALL.md
+++ b/documentation/INSTALL.md
@@ -13,11 +13,11 @@ The code has been tested with Python 3.8, CUDA 10.2 and PyTorch 1.7.1 on Ubuntu 
     conda create -n shapy python=3.8 -y
     conda activate shapy
     conda install pytorch==1.7.1 torchvision==0.8.2 cpuonly -c pytorch -y
+    REM install Pillow through conda to avoid DLL load failures
+    conda install pillow -y
     REM pip>=24 cannot install omegaconf 2.0.6
     python -m pip install pip==23.3.1
     pip install -r requirements.txt
-    REM install Pillow through conda to avoid missing DLL errors on Windows
-    conda install pillow -y
 
     cd attributes
     python setup.py install
@@ -35,6 +35,10 @@ The code has been tested with Python 3.8, CUDA 10.2 and PyTorch 1.7.1 on Ubuntu 
 **Note:** If the requirements installation complains about invalid metadata for
 `omegaconf==2.0.6`, make sure `python -m pip --version` reports a version below
 24.0 and reinstall pip as shown above.
+
+If Pillow was installed via pip previously and you still get
+`ImportError: DLL load failed while importing _imaging`, uninstall it with
+`pip uninstall Pillow` and reinstall via `conda install pillow -y`.
 
 ### Body model and model data
 

--- a/regressor/inference.py
+++ b/regressor/inference.py
@@ -1,0 +1,82 @@
+import argparse
+import os
+import os.path as osp
+from typing import Sequence
+
+from PIL import Image
+from loguru import logger
+import torch
+from torchvision import transforms
+from omegaconf import OmegaConf
+
+from human_shape.config.defaults import conf as default_conf
+from human_shape.models.build import build_model
+from human_shape.utils.checkpointer import Checkpointer
+from human_shape.data.structures import AbstractStructure, StructureList
+
+
+@torch.no_grad()
+def load_model(cfg_path: str, device: torch.device, *, output_folder: str) -> torch.nn.Module:
+    cfg = default_conf.copy()
+    cfg.merge_with(OmegaConf.load(cfg_path))
+    cfg.is_training = False
+    cfg.use_cuda = device.type == "cuda"
+    cfg.output_folder = output_folder
+
+    model_dict = build_model(cfg)
+    model = model_dict["network"].to(device)
+
+    checkpoint_folder = osp.join(osp.expandvars(cfg.output_folder), cfg.checkpoint_folder)
+    os.makedirs(checkpoint_folder, exist_ok=True)
+    checkpointer = Checkpointer(model, save_dir=checkpoint_folder, pretrained=cfg.pretrained)
+    checkpointer.load_checkpoint()
+    model.eval()
+    return model, cfg
+
+
+def preprocess_image(img_path: str, mean: Sequence[float], std: Sequence[float], crop_size: int) -> torch.Tensor:
+    tf = transforms.Compose([
+        transforms.Resize(crop_size),
+        transforms.CenterCrop(crop_size),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=mean, std=std),
+    ])
+    img = Image.open(img_path).convert("RGB")
+    return tf(img).unsqueeze(0)
+
+
+@torch.no_grad()
+def infer_betas(model: torch.nn.Module, image: torch.Tensor, device: torch.device) -> torch.Tensor:
+    target = AbstractStructure()
+    target.add_field("gender", "n")
+    targets = StructureList([target])
+    output = model(image.to(device), targets=targets, compute_losses=False)
+    stage_key = output.get("stage_keys", ["stage_02"])[-1]
+    betas = output[stage_key]["betas"]
+    return betas.squeeze(0).cpu()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="SHAPY single image inference")
+    parser.add_argument("--image-path", required=True, help="Path to an aligned full-body image")
+    parser.add_argument("--exp-cfg", default="configs/b2a_expose_hrnet_demo.yaml", help="Path to experiment config")
+    parser.add_argument(
+        "--output-folder",
+        default="../data/trained_models/shapy/SHAPY_A",
+        help="Folder containing trained checkpoints",
+    )
+    parser.add_argument("--cpu", action="store_true", help="Force CPU inference even if CUDA is available")
+    args = parser.parse_args()
+
+    device = torch.device("cpu" if args.cpu or not torch.cuda.is_available() else "cuda")
+    model, cfg = load_model(args.exp_cfg, device, output_folder=args.output_folder)
+
+    part_key = cfg.get("part_key", "pose")
+    transf_cfg = cfg.datasets.get(part_key, {}).get("transforms", {})
+    crop_size = transf_cfg.get("crop_size", 256)
+    mean = transf_cfg.get("mean", (0.485, 0.456, 0.406))
+    std = transf_cfg.get("std", (0.229, 0.224, 0.225))
+
+    image = preprocess_image(args.image_path, mean, std, crop_size)
+    betas = infer_betas(model, image, device)
+    logger.info(f"Betas: {betas.tolist()}")


### PR DESCRIPTION
## Summary
- update INSTALL.md to describe Conda based installation on Windows (CPU only)
- add `regressor/inference.py` for predicting SMPL betas from a single aligned image

## Testing
- `python -m py_compile regressor/inference.py`

------
https://chatgpt.com/codex/tasks/task_e_688ad282b39c832f9f913166539798bc